### PR TITLE
Add DAX measure generation script

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,17 @@ The purpose of this repository is to automate Power BI tasks using TMDL format.
 - Manage Power BI datasets and data sources
 - Integrate with other tools and services
 
+## Generating DAX Measures
+A new script `scripts/generate_dax_measures.py` has been added to generate DAX measures programmatically based on a JSON input.
+
+### Usage
+1. Prepare a JSON file containing measure definitions. Refer to `examples/sample_measures.json` for the input format.
+2. Run the script with the JSON file as input and specify the output file for the generated DAX measures.
+
+```sh
+python scripts/generate_dax_measures.py path/to/input.json path/to/output.dax
+```
+
 ## Contribution Guidelines
 We welcome contributions to this project. To contribute, please follow these steps:
 1. Fork the repository

--- a/examples/sample_measures.json
+++ b/examples/sample_measures.json
@@ -1,0 +1,27 @@
+[
+    {
+        "name": "Total Sales",
+        "expression": "SUM(Sales[Amount])",
+        "formatString": "#,##0.00",
+        "displayFolder": "Sales Metrics",
+        "description": "This measure calculates the total sales amount across all transactions.",
+        "isHidden": false,
+        "isPrivate": false,
+        "detailRowsExpression": "SUMMARIZE(Sales, Sales[OrderID], Sales[OrderDate])",
+        "annotations": {
+            "category": "KeyMetric",
+            "source": "ETL Process"
+        },
+        "formatStringExpression": "IF([Total Sales] > 1000, \"#,##0\", \"#.00\")",
+        "dataType": "double",
+        "summarizeBy": "sum",
+        "properties": {
+            "customLabel": "Critical Metric",
+            "priority": "High"
+        },
+        "isAggDependent": true,
+        "metadata": {
+            "tags": ["Finance", "High Priority"]
+        }
+    }
+]

--- a/examples/sample_measures.tmdl
+++ b/examples/sample_measures.tmdl
@@ -1,0 +1,24 @@
+table Sales
+
+    measure "Total Sales" = SUM(Sales[Amount])
+        formatString: "#,##0.00"
+        displayFolder: "Sales Metrics"
+        description: "This measure calculates the total sales amount across all transactions."
+        isHidden: false
+        isPrivate: false
+        detailRowsExpression: SUMMARIZE(Sales, Sales[OrderID], Sales[OrderDate])
+        annotations: {
+            category: "KeyMetric",
+            source: "ETL Process"
+        }
+        formatStringExpression: IF([Total Sales] > 1000, "#,##0", "#.00")
+        dataType: double
+        summarizeBy: sum
+        properties: {
+            customLabel: "Critical Metric",
+            priority: "High"
+        }
+        isAggDependent: true
+        metadata: {
+            tags: ["Finance", "High Priority"]
+        }

--- a/scripts/generate_dax_measures.py
+++ b/scripts/generate_dax_measures.py
@@ -1,0 +1,53 @@
+import json
+
+def generate_dax_measures(json_file, output_file):
+    with open(json_file, 'r') as file:
+        measures = json.load(file)
+
+    dax_measures = []
+    for measure in measures:
+        dax_measure = f'measure "{measure["name"]}" = {measure["expression"]}\n'
+        if "formatString" in measure:
+            dax_measure += f'    formatString: "{measure["formatString"]}"\n'
+        if "displayFolder" in measure:
+            dax_measure += f'    displayFolder: "{measure["displayFolder"]}"\n'
+        if "description" in measure:
+            dax_measure += f'    description: "{measure["description"]}"\n'
+        if "isHidden" in measure:
+            dax_measure += f'    isHidden: {str(measure["isHidden"]).lower()}\n'
+        if "isPrivate" in measure:
+            dax_measure += f'    isPrivate: {str(measure["isPrivate"]).lower()}\n'
+        if "detailRowsExpression" in measure:
+            dax_measure += f'    detailRowsExpression: {measure["detailRowsExpression"]}\n'
+        if "annotations" in measure:
+            annotations = ', '.join([f'{k}: "{v}"' for k, v in measure["annotations"].items()])
+            dax_measure += f'    annotations: {{{annotations}}}\n'
+        if "formatStringExpression" in measure:
+            dax_measure += f'    formatStringExpression: {measure["formatStringExpression"]}\n'
+        if "dataType" in measure:
+            dax_measure += f'    dataType: {measure["dataType"]}\n'
+        if "summarizeBy" in measure:
+            dax_measure += f'    summarizeBy: {measure["summarizeBy"]}\n'
+        if "properties" in measure:
+            properties = ', '.join([f'{k}: "{v}"' for k, v in measure["properties"].items()])
+            dax_measure += f'    properties: {{{properties}}}\n'
+        if "isAggDependent" in measure:
+            dax_measure += f'    isAggDependent: {str(measure["isAggDependent"]).lower()}\n'
+        if "metadata" in measure:
+            metadata = ', '.join([f'{k}: "{v}"' for k, v in measure["metadata"].items()])
+            dax_measure += f'    metadata: {{{metadata}}}\n'
+        dax_measures.append(dax_measure)
+
+    with open(output_file, 'w') as file:
+        file.write('\n'.join(dax_measures))
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description='Generate DAX measures from a JSON file.')
+    parser.add_argument('json_file', type=str, help='Path to the JSON file containing measure definitions.')
+    parser.add_argument('output_file', type=str, help='Path to the output file to save the generated DAX measures.')
+
+    args = parser.parse_args()
+
+    generate_dax_measures(args.json_file, args.output_file)


### PR DESCRIPTION
Fixes #4

Add script to generate DAX measures programmatically based on JSON input.

* **New Script**: Add `scripts/generate_dax_measures.py` to read a JSON file containing measure definitions and generate corresponding DAX measures in TMDL format.
* **README Update**: Update `README.md` to include instructions on how to use the new script for generating DAX measures.
* **Sample JSON**: Add `examples/sample_measures.json` to demonstrate the input format for the new script.
* **Sample TMDL**: Add `examples/sample_measures.tmdl` to demonstrate the output format for the new script.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/pranamg/TMDL-Automation/pull/27?shareId=a2311907-b303-412e-a2f4-e0479b29bea6).